### PR TITLE
Fix for issue #5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,3 +331,5 @@ ASALocalRun/
 NAudio.dll
 OriginalSoundTrack.dll
 OriginalSoundTrack.zip
+#test file
+test.txt

--- a/OriginalSoundTrack/OriginalSoundTrack.cs
+++ b/OriginalSoundTrack/OriginalSoundTrack.cs
@@ -39,11 +39,12 @@ namespace OriginalSoundTrack {
         private FileInfo[] soundFiles; // array of files found in the plugin folder
         private List<Music> musics = new List<Music>(); // list of main music objects.
         private AudioFileReader currentSong;
-        private string currentSongFullName = ""; // helpful for not restarting a song when it's already playing.
+        private string currentSongFullName = null; // helpful for not restarting a song when it's already playing.
         private bool startedTeleporterEvent = false; // tracks the first interaction with the tele.
         private bool songPaused = false; // for pausing the music when the player pauses.
         private float globalMusicVolume = 0.5f; // default global music volume.
         private bool shouldLoop = true; // should songs loop when they end?
+        private bool shouldPool = false; // should include songs from normal soundtrack?
         private string oldMusicVolume = ""; // what the music convar was before we override it.
         private string currentScene = ""; // helpful for picking out boss music.
         private System.Random rnd = new System.Random(); // helpful for picking random music.
@@ -52,8 +53,10 @@ namespace OriginalSoundTrack {
         //The Awake() method is run at the very start when the game is initialized.
         public void Awake() {
             var pluginPath = System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            var musicPath = pluginPath;
+            var musicPath = pluginPath;            
 
+            //attempt to parse settingsXml. Upon sucessful parse, default settings are changed and new music
+            //is added to list musics. Upon failure, default settings kept and list musics is kept empty.
             try {
                 var settingsXml = new XmlDocument();
                 settingsXml.Load(pluginPath + "/settings.xml");
@@ -61,6 +64,7 @@ namespace OriginalSoundTrack {
 
                 globalMusicVolume = float.Parse(settings["volume"].InnerText, CultureInfo.InvariantCulture);
                 shouldLoop = settings["loop"].InnerText.ToLower() == "true";
+                shouldPool = settings["pool"].InnerText.ToLower() == "true";
 
                 if (settings["music-path"] != null) {
                     musicPath = settings["music-path"].InnerText;
@@ -164,7 +168,8 @@ namespace OriginalSoundTrack {
                     startedTeleporterEvent = false;
                     PickOutMusic();
                 }
-            };
+            };            
+
         }
 
         private FileInfo[] SearchForAudioFiles(string path) {
@@ -234,47 +239,71 @@ namespace OriginalSoundTrack {
                 Debug.Log("choosing random song...");
             #endif
             // if we are here, then we failed to pick a music, so pick one at random from all of them we found.
-            tries = 0;
-            while (randFile == currentSongFullName && tries < 10) {
-                randFile = soundFiles[rnd.Next(soundFiles.Length)].FullName;
-                tries++;
+            //if setting shouldPool is enabled, use the normal soundtrack from the game.
+            if(shouldPool){
+                //no new music is playing, so none is picked
+                randFile = null;
+            }else{
+                tries = 0;
+                while (randFile == currentSongFullName && tries < 10) {
+                    randFile = soundFiles[rnd.Next(soundFiles.Length)].FullName;
+                    tries++;
+                }                
             }
-            StartCoroutine(PlayMusic(randFile));
+            StartCoroutine(PlayMusic(randFile));            
         }
 
-        private IEnumerator<WaitForSeconds> PlayMusic(string file, float volume = 1f) {
-            if (file != currentSongFullName) {
-                currentSongFullName = file;
-                if (outputDevice.PlaybackState == PlaybackState.Playing) {
-                    fader.BeginFadeOut(1500);
-                    yield return new WaitForSeconds(1.5f);
-                    outputDevice.Stop();
-                    currentSong = null;
+        private IEnumerator<WaitForSeconds> PlayMusic(string file, float volume = 1f) {            
+            if (outputDevice.PlaybackState == PlaybackState.Playing) {
+                fader.BeginFadeOut(1500);
+                yield return new WaitForSeconds(1.5f);
+                outputDevice.Stop();
+                currentSong = null;
+            }
+            if(file == null){
+                //no new music was selected, so return to OST pool
+                //If already playing OST music from previous scene, 
+                //then no need to unmute normal music again
+                if(currentSongFullName!=null){
+                    currentSongFullName = null;
+                    unmuteNormalMusic();
+                }                
+                #if DEBUG
+                    Debug.Log("PlayMusic: Playing music from OST");
+                #endif
+            }else{
+                if (file != currentSongFullName) {
+                    //new music provided, play that music.
+                    //if we were already playing new music, 
+                    //then don't mute normal volume again
+                    if(currentSongFullName == null){
+                        muteNormalMusic();
+                    }
+                    currentSongFullName = file;
+                    currentSong = new AudioFileReader(file);
+                    currentSong.Volume = volume * globalMusicVolume;
+                    var looper = new LoopStream(currentSong, shouldLoop);
+                    fader = new FadeInOutSampleProvider(new WaveToSampleProvider(looper));
+                    outputDevice.Init(fader);
+                    #if DEBUG
+                        Debug.Log("====== Now Playing: " + file);
+                    #endif
+                    outputDevice.Play();
+                    songPaused = false;
+                } else {
+                    #if DEBUG
+                        Debug.Log("PlayMusic: Already playing: " + file);
+                    #endif
                 }
-                currentSong = new AudioFileReader(file);
-                currentSong.Volume = volume * globalMusicVolume;
-                var looper = new LoopStream(currentSong, shouldLoop);
-                fader = new FadeInOutSampleProvider(new WaveToSampleProvider(looper));
-                outputDevice.Init(fader);
-                #if DEBUG
-                    Debug.Log("====== Now Playing: " + file);
-                #endif
-                outputDevice.Play();
-                songPaused = false;
-            } else {
-                #if DEBUG
-                    Debug.Log("PlayMusic: Already playing: " + file);
-                #endif
             }
         }
 
-        public void Update() {
+        public void Update() {     
+            //obtain user-set music volume convar
             if (oldMusicVolume == "" && RoR2.Console.instance != null) {
                 var convar = RoR2.Console.instance.FindConVar("volume_music");
-                // set in game music volume to 0 so we hear the new music only.
                 if (convar != null) {
                     oldMusicVolume = convar.GetString();
-                    convar.SetString("0");
                 }
             }
         }
@@ -289,10 +318,32 @@ namespace OriginalSoundTrack {
             }
         }
 
+        //If the normal music is playing, then do not override this value on game exit
         private void OnDestroy() {
             var convar = RoR2.Console.instance.FindConVar("volume_music");
-            if (convar != null) {
+            if (convar != null && currentSongFullName != null) {
                 convar.SetString(oldMusicVolume);
+            }
+        }
+
+        private void muteNormalMusic(){
+            if (RoR2.Console.instance != null) {
+                var convar = RoR2.Console.instance.FindConVar("volume_music");
+                // set in game music volume to 0 so we hear the new music only.
+                if (convar != null) {
+                    oldMusicVolume = convar.GetString();
+                    convar.SetString("0");
+                }
+            }
+        }
+
+        private void unmuteNormalMusic(){
+            if (RoR2.Console.instance != null) {
+                var convar = RoR2.Console.instance.FindConVar("volume_music");
+                // reset in game music volume so we hear the normal music.
+                if (convar != null && !oldMusicVolume.Equals(String.Empty)) {
+                    convar.SetString(oldMusicVolume);
+                }
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@ Music files can be in .mp3 or .wav format (with those exact extensions).
 Make sure the filenames match what's in settings.xml (or edit settings.xml to match your files.)
 
 If you delete settings.xml, don't match your filenames with `<song>` tags, or delete all `<song>` tags, then the
-plugin will just choose random music it found.
+plugin will just choose random music it found, or, if the property `<pool>` is set, the plugin will play the normal
+music from the game.
 
 ## settings.xml
 
 If your files match all the song "names", then you don't need to do anything else, but feel free to customize.
 
-If the plugin fails to match a song for a scene, it will just choose a random one it found in the plugin directory.
+If the plugin fails to match a song for a scene, it will just choose a random one it found in the plugin directory or music from the game.
 
 Put scene IDs in the "scenes" attribute to have audio play on that scene in settings.xml.
 The scenes attribute is comma separated. A scene only has to be "contained" in the real scene ID for it to match:
@@ -47,6 +48,8 @@ among the matching songs.
 The top level `<volume>` tag is the master volume for all this plugin's music. Again, a decimal between 0 and 1.
 
 The top level `<loop>` tag determines if music should loop or pick another song (from matching songs) after a song ends.
+
+The top level `<pool>` tag determines if music should be pooled from the game's own music if a song is not defined or cannot be found for that scene.
 
 The top level `<music-path>` tag specifies where the plugin should scan for music. It does not traverse down directories.
 The default path it scans for music is: `Risk of Rain 2\BepInEx\plugins\OriginalSoundTrack`

--- a/settings.xml
+++ b/settings.xml
@@ -6,6 +6,9 @@
     <!-- Should music loop? If not true, then another song is selected from scene matches -->
     <loop>true</loop>
 
+    <!-- Should include music in Risk of Rain 2 OST pool? If true, then normal soundtrack is played in place of absent music defiend here -->
+    <pool>true</pool>
+
     <!-- To have this plugin scan a different directory for music files,
         Uncomment <music-path> below (remove <!- - and - -> from the line below) -->
 


### PR DESCRIPTION
fixes #5
Thoroughly tested, however there is a bug where if the player quits to desktop during a run (not from title screen), method OnDestroy is not called and in-game music volume remains 0 upon next startup.
README.md was updated to reflect these changes.
I placed some comments in changed methods for clarity.